### PR TITLE
Unity Collaborate & Quality of life fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ AssetStoreTools/
 Library/
 source/PluginDev/ProjectSettings/
 Temp/
+UnityPackageManager/
 
 # Jar Resolver
 PlayServicesResolver/
@@ -17,3 +18,6 @@ PlayServicesResolver.meta
 
 # Unitypackage build process
 build/
+
+# CloudOnce Specific
+CloudOnceSettings.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,6 @@ source/PluginDev/ProjectSettings/
 Temp/
 UnityPackageManager/
 
-# Jar Resolver
-PlayServicesResolver/
-PlayServicesResolver.meta
-
 # Unitypackage build process
 build/
 

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Data/CloudOncePaths.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Data/CloudOncePaths.cs
@@ -11,7 +11,7 @@ public static class CloudOncePaths
     public const string Android = plugins + "/Android";
     public const string GameCircleLib = Android + "/gamecircle_lib";
     public const string GooglePlayLib = gpgs + "/Plugins/Android/GooglePlayGamesManifest.plugin";
-    public const string Settings = "ProjectSettings/CloudOnceSettings.txt";
+    public const string Settings = cloudOnce + "/CloudOnceSettings.txt";
 
     private const string cloudOnce = "Assets/Extensions/CloudOnce";
     private const string gpgs = "Assets/Extensions/GooglePlayGames";

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7a2dfa02ce50405eb783563bf92696a9
+folderAsset: yes
+timeCreated: 1448926447
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1453b333ee4d474eab390013d4e54e01
+folderAsset: yes
+timeCreated: 1448926516
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.IOSResolver_v1.2.52.0.dll.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.IOSResolver_v1.2.52.0.dll.meta
@@ -1,0 +1,36 @@
+fileFormatVersion: 2
+guid: 9522b48439054e9e8c2b81408c99fbc6
+labels:
+- gvh
+- gvh_targets-editor
+- gvh_version-1.2.52.0
+timeCreated: 1507827263
+licenseType: Free
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.JarResolver_v1.2.52.0.dll.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.JarResolver_v1.2.52.0.dll.meta
@@ -1,0 +1,36 @@
+fileFormatVersion: 2
+guid: fb2433b636ac4328bdd5c4163a296af6
+labels:
+- gvh
+- gvh_targets-editor
+- gvh_version-1.2.52.0
+timeCreated: 1507827265
+licenseType: Free
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.VersionHandler.dll.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.VersionHandler.dll.meta
@@ -1,0 +1,36 @@
+fileFormatVersion: 2
+guid: f6d60494f92848158e48099ad010f804
+labels:
+- gvh
+- gvh_targets-editor
+- gvh_version-1.2.52.0
+timeCreated: 1473798236
+licenseType: Pro
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.VersionHandlerImpl_v1.2.52.0.dll.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/Google.VersionHandlerImpl_v1.2.52.0.dll.meta
@@ -1,0 +1,36 @@
+fileFormatVersion: 2
+guid: b39a37b255484392bf3a79d0f72d91b7
+labels:
+- gvh
+- gvh_targets-editor
+- gvh_version-1.2.52.0
+timeCreated: 1507827258
+licenseType: Free
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/play-services-resolver_v1.2.52.0.txt
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/play-services-resolver_v1.2.52.0.txt
@@ -1,0 +1,4 @@
+Assets/PlayServicesResolver/Editor/Google.IOSResolver_v1.2.52.0.dll
+Assets/PlayServicesResolver/Editor/Google.JarResolver_v1.2.52.0.dll
+Assets/PlayServicesResolver/Editor/Google.VersionHandler.dll
+Assets/PlayServicesResolver/Editor/Google.VersionHandlerImpl_v1.2.52.0.dll

--- a/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/play-services-resolver_v1.2.52.0.txt.meta
+++ b/source/PluginDev/Assets/Extensions/PlayServicesResolver/Editor/play-services-resolver_v1.2.52.0.txt.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 4e0751d6e9e3459dafd931587751031e
+labels:
+- gvh
+- gvh_manifest
+- gvh_version-1.2.52.0
+timeCreated: 1474401009
+licenseType: Pro
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## What changed?

- ProjectSettings/CloudOnceSettings.txt was moved to Assets/Extensions/CloudOnce/CloudOnceSettings.txt.
  - Unity Collaborate does not scan the ProjectSettings folder.
  - It makes sense to put extension related configuration with the extension.
  - If someone deletes the extension, a file will be left behind creating unnecessary clutter.

- PlayServicesResolver was added to Extensions/
  - Makes it easier for new collaborators as they won't be missing dependencies.
  - Unitypackage deployment is simplified.
  - Collaborators will not have version mismatches causing unknown errors.

_issue #26_
