### PR TITLE
tvOS support

### DIFF
--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/iOSPostBuild.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/iOSPostBuild.cs
@@ -26,7 +26,7 @@ namespace CloudOnce.Internal.Editor.Utils
         [PostProcessBuild]
         public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
         {
-            if (target != BuildTarget.iOS)
+            if (target != BuildTarget.iOS && target != BuildTarget.tvOS)
             {
                 return;
             }


### PR DESCRIPTION
Post build should also add gamekit to UIRequiredDeviceCapabilities

## What changed?
"if (target != BuildTarget.iOS)" changed to "if (target != BuildTarget.iOS && target != BuildTarget.tvOS)"
