### PR TITLE
Added ability to access per platform id outside of plugin

### DIFF
--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/AchievementsTemplate.cs.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/AchievementsTemplate.cs.txt
@@ -2,6 +2,7 @@
 // Copyright (c) 2016 Jan Ivar Z. Carlsen, Sindri Jóelsson. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
+using System.Collections.Generic;
 
 namespace CloudOnce
 {
@@ -13,5 +14,20 @@ namespace CloudOnce
     /// </summary>
     public static class Achievements
     {
-// ACHIEVEMENT_IDS    }
+// ACHIEVEMENT_IDS
+
+        public static string GetPlatformID(string internalId)
+        {
+            if (addAchievements.ContainsKey(internalId)) {
+                return addAchievements[internalId].ID;
+            } else {
+                return "";
+            }
+        }
+
+        private static Dictionary<string, UnifiedAchievement> addAchievements = new Dictionary<string, UnifiedAchievement>
+        {
+// ACHIEVEMENT_DICTIONARY
+        };
+    }
 }

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/AchievementsTemplate.cs.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/AchievementsTemplate.cs.txt
@@ -2,10 +2,10 @@
 // Copyright (c) 2016 Jan Ivar Z. Carlsen, Sindri Jóelsson. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
-using System.Collections.Generic;
 
 namespace CloudOnce
 {
+    using System.Collections.Generic;
     using Internal;
 
     /// <summary>
@@ -15,17 +15,14 @@ namespace CloudOnce
     public static class Achievements
     {
 // ACHIEVEMENT_IDS
-
         public static string GetPlatformID(string internalId)
         {
-            if (addAchievements.ContainsKey(internalId)) {
-                return addAchievements[internalId].ID;
-            } else {
-                return "";
-            }
+            return s_achievementDictionary.ContainsKey(internalId)
+                ? s_achievementDictionary[internalId].ID
+                : string.Empty;
         }
 
-        private static Dictionary<string, UnifiedAchievement> addAchievements = new Dictionary<string, UnifiedAchievement>
+        private static readonly Dictionary<string, UnifiedAchievement> s_achievementDictionary = new Dictionary<string, UnifiedAchievement>
         {
 // ACHIEVEMENT_DICTIONARY
         };

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/LeaderboardsTemplate.cs.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/LeaderboardsTemplate.cs.txt
@@ -2,6 +2,7 @@
 // Copyright (c) 2016 Jan Ivar Z. Carlsen, Sindri Jóelsson. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
+using System.Collections.Generic;
 
 namespace CloudOnce
 {
@@ -13,5 +14,20 @@ namespace CloudOnce
     /// </summary>
     public static class Leaderboards
     {
-// LEADERBOARD_IDS    }
+// LEADERBOARD_IDS
+    
+        public static string GetPlatformID(string internalId)
+        {
+            if (allLeaderboards.ContainsKey(internalId)) {
+                return allLeaderboards[internalId].ID;
+            } else {
+                return "";
+            }
+        }
+
+        private static Dictionary<string, UnifiedLeaderboard> allLeaderboards = new Dictionary<string, UnifiedLeaderboard>
+        {
+// LEADERBOARD_DICTIONARY
+        };
+    }
 }

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/LeaderboardsTemplate.cs.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Data/Templates/LeaderboardsTemplate.cs.txt
@@ -2,10 +2,10 @@
 // Copyright (c) 2016 Jan Ivar Z. Carlsen, Sindri Jóelsson. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
-using System.Collections.Generic;
 
 namespace CloudOnce
 {
+    using System.Collections.Generic;
     using Internal;
 
     /// <summary>
@@ -15,17 +15,14 @@ namespace CloudOnce
     public static class Leaderboards
     {
 // LEADERBOARD_IDS
-    
         public static string GetPlatformID(string internalId)
         {
-            if (allLeaderboards.ContainsKey(internalId)) {
-                return allLeaderboards[internalId].ID;
-            } else {
-                return "";
-            }
+            return s_leaderboardDictionary.ContainsKey(internalId)
+                ? s_leaderboardDictionary[internalId].ID
+                : string.Empty;
         }
 
-        private static Dictionary<string, UnifiedLeaderboard> allLeaderboards = new Dictionary<string, UnifiedLeaderboard>
+        private static readonly Dictionary<string, UnifiedLeaderboard> s_leaderboardDictionary = new Dictionary<string, UnifiedLeaderboard>
         {
 // LEADERBOARD_DICTIONARY
         };

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/SerializationUtils.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/SerializationUtils.cs
@@ -236,6 +236,7 @@ namespace CloudOnce.Internal.Editor.Utils
                 }
 
                 var builder = new StringBuilder();
+                var dictionaryBuilder = new StringBuilder();
                 foreach (var idData in cloudConfig.AchievementIDs)
                 {
                     var propertyString = idPropertyTemplate;
@@ -244,7 +245,13 @@ namespace CloudOnce.Internal.Editor.Utils
                     propertyString = propertyString.Replace("APPLEID", idData.AppleId);
                     propertyString = propertyString.Replace("GOOGLEID", idData.GoogleId);
                     builder.AppendLine(propertyString).AppendLine();
+
+                    var dictionaryString = "            { \"INTERNALID\", FIELDNAME },";
+                    dictionaryString = dictionaryString.Replace("FIELDNAME", "s_" + FirstLetterToLowerCase(idData.InternalId));
+                    dictionaryString = dictionaryString.Replace("INTERNALID", idData.InternalId);
+                    dictionaryBuilder.AppendLine(dictionaryString);
                 }
+                if (cloudConfig.AchievementIDs.Count > 0) dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
 
                 builder.AppendLine(allAchievementsTemplate).AppendLine("        {");
                 foreach (var idData in cloudConfig.AchievementIDs)
@@ -255,6 +262,7 @@ namespace CloudOnce.Internal.Editor.Utils
                 builder.AppendLine("        };");
 
                 newAchievementsScript = newAchievementsScript.Replace("// ACHIEVEMENT_IDS", builder.ToString());
+                newAchievementsScript = newAchievementsScript.Replace("// ACHIEVEMENT_DICTIONARY", dictionaryBuilder.ToString());
 
                 writer.Write(newAchievementsScript);
             }
@@ -291,6 +299,7 @@ namespace CloudOnce.Internal.Editor.Utils
                 }
 
                 var builder = new StringBuilder();
+                var dictionaryBuilder = new StringBuilder();
                 for (var i = 0; i < cloudConfig.LeaderboardIDs.Count; i++)
                 {
                     var propertyString = idPropertyTemplate;
@@ -299,13 +308,21 @@ namespace CloudOnce.Internal.Editor.Utils
                     propertyString = propertyString.Replace("APPLEID", cloudConfig.LeaderboardIDs[i].AppleId);
                     propertyString = propertyString.Replace("GOOGLEID", cloudConfig.LeaderboardIDs[i].GoogleId);
                     builder.AppendLine(propertyString);
+
+                    var dictionaryString = "            { \"INTERNALID\", FIELDNAME },";
+                    dictionaryString = dictionaryString.Replace("FIELDNAME", "s_" + FirstLetterToLowerCase(cloudConfig.LeaderboardIDs[i].InternalId));
+                    dictionaryString = dictionaryString.Replace("INTERNALID", cloudConfig.LeaderboardIDs[i].InternalId);
+                    dictionaryBuilder.AppendLine(dictionaryString);
+
                     if (i != cloudConfig.LeaderboardIDs.Count - 1)
                     {
                         builder.AppendLine();
                     }
                 }
+                if (cloudConfig.LeaderboardIDs.Count > 0) dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
 
                 newLeaderboardsScript = newLeaderboardsScript.Replace("// LEADERBOARD_IDS", builder.ToString());
+                newLeaderboardsScript = newLeaderboardsScript.Replace("// LEADERBOARD_DICTIONARY", dictionaryBuilder.ToString());
 
                 writer.Write(newLeaderboardsScript);
             }

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/SerializationUtils.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/SerializationUtils.cs
@@ -251,7 +251,11 @@ namespace CloudOnce.Internal.Editor.Utils
                     dictionaryString = dictionaryString.Replace("INTERNALID", idData.InternalId);
                     dictionaryBuilder.AppendLine(dictionaryString);
                 }
-                if (cloudConfig.AchievementIDs.Count > 0) dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
+
+                if (cloudConfig.AchievementIDs.Count > 0)
+                {
+                    dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
+                }
 
                 builder.AppendLine(allAchievementsTemplate).AppendLine("        {");
                 foreach (var idData in cloudConfig.AchievementIDs)
@@ -319,7 +323,11 @@ namespace CloudOnce.Internal.Editor.Utils
                         builder.AppendLine();
                     }
                 }
-                if (cloudConfig.LeaderboardIDs.Count > 0) dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
+
+                if (cloudConfig.LeaderboardIDs.Count > 0)
+                {
+                    dictionaryBuilder.Remove(dictionaryBuilder.Length - 2 , 2);
+                }
 
                 newLeaderboardsScript = newLeaderboardsScript.Replace("// LEADERBOARD_IDS", builder.ToString());
                 newLeaderboardsScript = newLeaderboardsScript.Replace("// LEADERBOARD_DICTIONARY", dictionaryBuilder.ToString());

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/ValidationUtils.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/Utils/ValidationUtils.cs
@@ -289,15 +289,21 @@ namespace CloudOnce.Internal.Editor.Utils
             return true;
         }
 
-        public static bool ConfigHasNoAchievementsNamedAll(List<PlatformIdData> achievementIds)
+        public static bool ConfigHasNoReservedIDs(List<PlatformIdData> platformIds, params string[] ids)
         {
-            var result = !achievementIds.Any(id => string.Equals(
-                id.InternalId,
-                "All",
-                StringComparison.InvariantCultureIgnoreCase));
-            if (!result)
+            if (ids == null || ids.Length == 0)
             {
-                EditorGUILayout.HelpBox("\"All\" internal achievement ID is reserved.", MessageType.Warning);
+                return true;
+            }
+
+            var result = true;
+            foreach (var id in ids)
+            {
+                if (platformIds.Any(p => string.Equals(p.InternalId, id, StringComparison.InvariantCultureIgnoreCase)))
+                {
+                    result = false;
+                    EditorGUILayout.HelpBox("\"" + id + "\" internal achievement ID is reserved.", MessageType.Warning);
+                }
             }
 
             return result;


### PR DESCRIPTION
## What changed?

Added a function to both the CloudOnce.Achievements and CloudOnce.Leaderboards generated files to obtain the per platform id from the internal id allowing for more functionality.

```csharp
string perPlatformID = CloudOnce.Leaderboards.GetPlatformID(internalID);
Cloud.Leaderboards.ShowOverlay(perPlatformID);
```