### PR TITLE
Restrict MenuLinks to be compiled in editor only

### DIFF
--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/MenuLinks.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/MenuLinks.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 
+#if UNITY_EDITOR
 namespace CloudOnce.Internal.Editor
 {
     using UnityEditor;
@@ -32,3 +33,4 @@ namespace CloudOnce.Internal.Editor
         }
     }
 }
+#endif


### PR DESCRIPTION
## What changed?

_Describe the changes you have made to improve this project._

This issue seemed to prevent iOS or Android builds since it also included editor script in project.
