### PR TITLE
Use UnityWebRequest result comparisons

### DIFF
--- a/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
@@ -414,11 +414,15 @@ namespace CloudOnce.Internal.Providers
 
         private IEnumerator DownloadPlayerImage(string url)
         {
-#if UNITY_2017_1_OR_NEWER
+#if UNITY_2017_2_OR_NEWER
             using (var request = UnityWebRequestTexture.GetTexture(url))
             {
                 yield return request.SendWebRequest();
+#if UNITY_2020_1_OR_NEWER
                 if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
+#else
+                if (request.isNetworkError || request.isHttpError)
+#endif
                 {
                     yield break;
                 }

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Providers/GooglePlayGames/GooglePlayGamesCloudProvider.cs
@@ -418,7 +418,7 @@ namespace CloudOnce.Internal.Providers
             using (var request = UnityWebRequestTexture.GetTexture(url))
             {
                 yield return request.SendWebRequest();
-                if (request.isNetworkError || request.isHttpError)
+                if (request.result == UnityWebRequest.Result.ConnectionError || request.result == UnityWebRequest.Result.ProtocolError)
                 {
                     yield break;
                 }


### PR DESCRIPTION
As of Unity 2020.2, `isNetworkError` and `isHttpError` are obsolete!

This change uses the `result` object for checking connection/protocol errors, which fixes the following warnings that show up in the Unity editor:

```
'UnityWebRequest.isNetworkError' is obsolete: 'UnityWebRequest.isNetworkError is deprecated. Use (UnityWebRequest.result == UnityWebRequest.Result.ConnectionError) instead.'
'UnityWebRequest.isHttpError' is obsolete: 'UnityWebRequest.isHttpError is deprecated. Use (UnityWebRequest.result == UnityWebRequest.Result.ProtocolError) instead.'
