### PR TITLE
Updated CloudOnce site/repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ CloudOnce has evolved a lot since then, and on June 1st 2016 it was made open-so
 
 ## Trollpants Game Studio games
 All the games created by Trollpants Game Studio have been released as open source. They all use CloudOnce and have been updated to run in Unity 2017.3. Check them out for examples of how CloudOnce can be used.
-* [Trollpants repositories](https://github.com/orgs/Trollpants/repositories)
-* [Trollpants WebGL builds](https://trollpants.github.io/)
+* [Trollpants GitHub](https://github.com/Trollpants)
+* [Trollpants WebGL builds](https://trollpants.github.io)
 
 ## License
 The contents of this project is licensed under the MIT license, unless other is specified in file header. See [LICENSE](./LICENSE) file in the project root for full license information.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 CloudOnce is a [Unity](https://unity3d.com/) plug-in that provides a unified game services API for [Google Play Game Services](https://github.com/playgameservices/play-games-plugin-for-unity/) and Apple Game Center (iOS & tvOS). Ease of use is the primary focus for the plug-in, but it also attempts to satisfy the needs of power users.
 
 ## Getting Started
-Download the [latest release](https://github.com/jizc/CloudOnce/releases/latest) and then check out the [Getting Started](https://jizc.github.io/CloudOnce/gettingStarted.html) guide for an overview of available features and how to implement them.
+Download the [latest release](https://github.com/CloudOnce/CloudOnce/releases/latest) and then check out the [Getting Started](https://cloudonce.github.io/gettingStarted.html) guide for an overview of available features and how to implement them.
 
 ## API Documentation
-If you need more technical or more complete documentation of the plug-in, you can check out the [API documentation](https://jizc.github.io/CloudOnce/api-docs/index.html).
+If you need more technical or more complete documentation of the plug-in, you can check out the [API documentation](https://cloudonce.github.io/api-docs/index.html).
 
 ## Building
 If you want to modify CloudOnce and build your own unitypackage, there are a few required steps.
@@ -32,8 +32,8 @@ CloudOnce has evolved a lot since then, and on June 1st 2016 it was made open-so
 
 ## Trollpants Game Studio games
 All the games created by Trollpants Game Studio have been released as open source. They all use CloudOnce and have been updated to run in Unity 2017.3. Check them out for examples of how CloudOnce can be used.
-* [Trollpants repository](https://github.com/jizc/Trollpants)
-* [Trollpants WebGL builds](https://jizc.github.io/Trollpants)
+* [Trollpants repositories](https://github.com/orgs/Trollpants/repositories)
+* [Trollpants WebGL builds](https://trollpants.github.io/)
 
 ## License
 The contents of this project is licensed under the MIT license, unless other is specified in file header. See [LICENSE](./LICENSE) file in the project root for full license information.

--- a/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/MenuLinks.cs
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/Internal/Editor/MenuLinks.cs
@@ -17,19 +17,19 @@ namespace CloudOnce.Internal.Editor
         [MenuItem("Window/CloudOnce/Getting Started Guide", false, 50)]
         private static void MenuItemGettingStartedGuides()
         {
-            Application.OpenURL("http://jizc.github.io/CloudOnce/gettingStarted.html");
+            Application.OpenURL("http://cloudonce.github.io/gettingStarted.html");
         }
 
         [MenuItem("Window/CloudOnce/API Documentation", false, 51)]
         private static void MenuItemAipDocumentation()
         {
-            Application.OpenURL("http://jizc.github.io/CloudOnce/api-docs/index.html");
+            Application.OpenURL("http://cloudonce.github.io/api-docs/index.html");
         }
 
         [MenuItem("Window/CloudOnce/GitHub Repository", false, 100)]
         private static void MenuItemGitHubRepo()
         {
-            Application.OpenURL("http://github.com/jizc/CloudOnce");
+            Application.OpenURL("http://github.com/CloudOnce/CloudOnce");
         }
     }
 }

--- a/source/PluginDev/Assets/Extensions/CloudOnce/readme.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/readme.txt
@@ -1,5 +1,5 @@
 CloudOnce - Unified Game Services API
-https://jizc.github.io/CloudOnce
+https://cloudonce.github.io/CloudOnce
 
 Description
 -----------

--- a/source/PluginDev/Assets/Extensions/CloudOnce/readme.txt
+++ b/source/PluginDev/Assets/Extensions/CloudOnce/readme.txt
@@ -1,5 +1,5 @@
 CloudOnce - Unified Game Services API
-https://cloudonce.github.io/CloudOnce
+https://cloudonce.github.io
 
 Description
 -----------


### PR DESCRIPTION
Hey! I know CloudOnce isn't updated much anymore, but I still use it frequently and love it 😄 

I noticed some of the links on Google, and this repo, were outdated since the site moved to [cloudonce.github.io](https://cloudonce.github.io/)

Just thought I'd change the links in `README.md` and the plugin itself to keep things up to date.